### PR TITLE
Modifications to set the beam position in X, Y, Z inside the macro files...

### DIFF
--- a/include/QweakSimPrimaryGeneratorActionMessenger.hh
+++ b/include/QweakSimPrimaryGeneratorActionMessenger.hh
@@ -62,6 +62,8 @@ private:
 
   G4UIcmdWithADoubleAndUnit*    SetPositionX_Cmd;
   G4UIcmdWithADoubleAndUnit*    SetPositionY_Cmd;
+  G4UIcmdWithADoubleAndUnit*    SetPositionZ_Cmd;
+
   G4UIcmdWithADoubleAndUnit*    SetDirectionX_Cmd;
   G4UIcmdWithADoubleAndUnit*    SetDirectionY_Cmd;
 

--- a/include/QweakSimUserInformation.hh
+++ b/include/QweakSimUserInformation.hh
@@ -67,13 +67,15 @@ public:
   //setter functions
   void SetBeamPositionX(G4double x) { fPositionX = x; };
   void SetBeamPositionY(G4double y) { fPositionY = y; };
+  void SetBeamPositionZ(G4double z) { fPositionZ = z; };
   void SetBeamDirectionX(G4double x) { fNormMomentumX = x; };
   void SetBeamDirectionY(G4double y) { fNormMomentumY = y; };
   
   //getter functions 
   G4double    GetBeamPositionX() const {return fPositionX;};
   G4double    GetBeamPositionY() const {return fPositionY;};
-  
+  G4double    GetBeamPositionZ() const {return fPositionZ;};
+
   G4double    GetNormMomentumX() const {return fNormMomentumX;};
   G4double    GetNormMomentumY() const {return fNormMomentumY;};
   G4ThreeVector GetNormMomentum() const {
@@ -93,6 +95,7 @@ private:
 
   G4double fPositionX;
   G4double fPositionY;
+  G4double fPositionZ;
   G4double fNormMomentumX;
   G4double fNormMomentumY;
 

--- a/myQweakCerenkovOnly.mac
+++ b/myQweakCerenkovOnly.mac
@@ -1,0 +1,138 @@
+#=================================================
+# Buddhini W. 01-27-2015
+# Macro file myQweakCerenkovOnly.mac
+# For simulating PMT DD effect
+#
+# Defaults to production LH2 simulation
+#=================================================
+
+#==========================
+# Store Tracks
+#==========================
+/tracking/storeTrajectory 1
+
+#==========================
+# Cerenkov Detector related
+#==========================
+#  Air     :without Cerenkov light production 
+#  Quartz  :with    Cerenkov light production
+# 
+# Angle is definedagaing vertical (y) axis
+# - a tilt angle of 0.0*deg means vertical 
+# - negative angle will tilt detector towards target
+
+/Cerenkov/SetCerenkovMaterial Quartz
+
+/Cerenkov/SetTiltingAngle           0.0 degree
+
+/Cerenkov/SetPreradiatorMaterial PBA
+
+# Define the number of Cereknov Bars
+/Cerenkov/SetNumberOfDetectors 8
+
+# Move Cerenkov Detectors to actual position 
+
+/Cerenkov/Cerenkov1/SetCenterPositionInY  334.724 cm
+/Cerenkov/Cerenkov1/SetCenterPositionInZ  576.665 cm
+
+/Cerenkov/Cerenkov2/SetCenterPositionInY  334.742 cm
+/Cerenkov/Cerenkov2/SetCenterPositionInZ  576.705 cm
+
+/Cerenkov/Cerenkov3/SetCenterPositionInY  334.738 cm
+/Cerenkov/Cerenkov3/SetCenterPositionInZ  577.020 cm
+
+/Cerenkov/Cerenkov4/SetCenterPositionInY  335.036 cm
+/Cerenkov/Cerenkov4/SetCenterPositionInZ  577.425 cm
+
+/Cerenkov/Cerenkov5/SetCenterPositionInY  335.074 cm
+/Cerenkov/Cerenkov5/SetCenterPositionInZ  577.515 cm
+
+/Cerenkov/Cerenkov6/SetCenterPositionInY  335.252 cm
+/Cerenkov/Cerenkov6/SetCenterPositionInZ  577.955 cm
+
+/Cerenkov/Cerenkov7/SetCenterPositionInY  335.224 cm
+/Cerenkov/Cerenkov7/SetCenterPositionInZ  577.885 cm
+
+/Cerenkov/Cerenkov8/SetCenterPositionInY  334.888 cm
+/Cerenkov/Cerenkov8/SetCenterPositionInZ  577.060 cm
+
+# ELOG Detector/74: Positions of background detectors
+#
+# For practical reasons (MD9 is in the same octant as MD1) the background
+# detector is here in the opposite octant than it actually was in (behind MD5).
+#
+# PRELIMINARY: More accurate numbers will require both the final survey
+# and the local survey of the monument with respect to the detector itself.
+#
+# "Det. Origin" is (assumed to be) the center of the back of the bar, outer edge.
+#
+# Z position of Det. Origin = 737.86 cm
+#   - 1 cm (half thickness) = 736.86 cm (Z in MC)
+# X position of Det. Origin = 377.84 cm
+#   - 9 cm (half width bar) = 368.84 cm (Y in MC)
+# Y position of Det. Origin =  72.86 cm (X in MC)
+
+#/Cerenkov/Cerenkov9/SetCenterPositionInX  -72.86 cm
+#/Cerenkov/Cerenkov9/SetCenterPositionInY  368.84 cm
+#/Cerenkov/Cerenkov9/SetCenterPositionInZ  736.86 cm
+
+#====================================
+# Event generator related
+#====================================
+
+# Usually this will be changed by a user macro that calls this 
+# configuration macro.
+
+# List of Generators (Included in src/QweakSimEPEvent.cc):
+#  0 - Combination of all reactions
+#  1 - LH2 elastic (default)
+#  2 - Al elastic
+#  3 - Al quasi-elastic (proton)
+#  4 - Al quasi-elastic (neutron)
+#  5 - LH2 inelastic (delta resonance)
+#  6 - Moller scattering
+#  7 - LH2 radiative lookup table (3.35 GeV)
+#  8 - Al quasi-elastic, Bosted
+#  88 - pion
+#  9 - Al nuclear inelastics SPS
+#  10 - Al GDR
+#  11 - Al inelastic (Bosted)
+#  12-17 - Al alloy (Zn, Mg, Cu, Cr, Fe, Si, respectively)
+
+/EventGen/SelectReactionType    1
+
+#==========================
+# Octant Selection
+#==========================
+# Valid values range from 0 to 12
+# default 0: events thrown in all octants
+# 1-8: events thrown in corresponding octant
+# 9-12: events thrown in two octants (9 for 1+5, 12 for 4+8)
+
+#/EventGen/SelectOctant 11
+
+#==========================
+# Primary generator
+#==========================
+# If below set points are not given, the beam starts
+# at (0,0,0) (inside QTOR)
+#
+/PrimaryEvent/SetBeamPositionX 0.0 cm
+/PrimaryEvent/SetBeamPositionY 250.0 cm
+/PrimaryEvent/SetBeamPositionZ 560.0 cm
+
+
+#====================================
+# Random Seed Handling
+#====================================
+
+# Inform the RunManager to systematically save the seed
+
+/random/setSavingFlag 0
+
+# Copy the following command line to your user macro and uncomment it 
+# to use the seeds of the last event in last run
+#/random/resetEngineFrom currentEvent.rndm
+# Or use specific seeds from file 'myseed.rndm', for example 
+#/random/resetEngineFrom myseed.rndm
+

--- a/myQweakCerenkovOnly.mac
+++ b/myQweakCerenkovOnly.mac
@@ -117,10 +117,13 @@
 # If below set points are not given, the beam starts
 # at (0,0,0) (inside QTOR)
 #
+# place beam after pre-radiator of MD3
 /PrimaryEvent/SetBeamPositionX 0.0 cm
-/PrimaryEvent/SetBeamPositionY 250.0 cm
-/PrimaryEvent/SetBeamPositionZ 560.0 cm
+/PrimaryEvent/SetBeamPositionY 335.0 cm
+/PrimaryEvent/SetBeamPositionZ 575.0 cm
 
+# Set energy of primary particle
+/EventGen/SetBeamEnergy    50 MeV
 
 #====================================
 # Random Seed Handling

--- a/src/QweakSimCerenkovDetector.cc
+++ b/src/QweakSimCerenkovDetector.cc
@@ -2177,7 +2177,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
     Radiator_Logical->SetVisAttributes(RadiatorVisAtt);
     
     G4VisAttributes* PMT_PbShieldVisAtt = new G4VisAttributes(blue);
-    PMT_PbShieldVisAtt->SetVisibility(true);
+    PMT_PbShieldVisAtt->SetVisibility(false);
     PMT_PbShield_Logical->SetVisAttributes(PMT_PbShieldVisAtt);    
 //------------------------------------------
 // Visual Attributes for:  CerenkovContainer
@@ -2192,7 +2192,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
 
 //Visual Attributes for:  Exo-Skelton
     G4VisAttributes* ExoSkeltonFrameVisAtt = new G4VisAttributes(darkbrown);
-    ExoSkeltonFrameVisAtt->SetVisibility(true);
+    ExoSkeltonFrameVisAtt->SetVisibility(false);
 //FrameVisAtt->SetForceWireframe(true);
 //FrameVisAtt->SetForceSolid(true);
     ExoSkeltonFrame_Logical->SetVisAttributes(ExoSkeltonFrameVisAtt);
@@ -2201,7 +2201,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
 // Visual Attributes for:  Detector Housing
 //------------------------------------------
     G4VisAttributes* FrameVisAtt = new G4VisAttributes(grey);
-    FrameVisAtt->SetVisibility(true);
+    FrameVisAtt->SetVisibility(false);
 //FrameVisAtt->SetForceWireframe(true);
 //FrameVisAtt->SetForceSolid(true);
     Frame_Logical->SetVisAttributes(FrameVisAtt);
@@ -2210,7 +2210,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
 // Visual Attributes for:  Side Brackets
 //------------------------------------------
     G4VisAttributes* SideBracketVisAtt = new G4VisAttributes(blue);
-    SideBracketVisAtt->SetVisibility(true);
+    SideBracketVisAtt->SetVisibility(false);
 //SideBracketVisAtt->SetForceWireframe(true);
 //SideBracketVisAtt->SetForceSolid(true);
     SideBracket_Logical->SetVisAttributes(SideBracketVisAtt);
@@ -2219,7 +2219,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
 // Visual Attributes for:  End Brackets
 //------------------------------------------
     G4VisAttributes* EndBracketVisAtt = new G4VisAttributes(blue);
-    EndBracketVisAtt->SetVisibility(true);
+    EndBracketVisAtt->SetVisibility(false);
 //EndBracketVisAtt->SetForceWireframe(true);
 //EndBracketVisAtt->SetForceSolid(true);
     EndBracket_Logical->SetVisAttributes(EndBracketVisAtt);
@@ -2228,7 +2228,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
 // Visual Attributes for:  Side Bracket Pads
 //------------------------------------------
     G4VisAttributes* SideBracketPadVisAtt = new G4VisAttributes(brown);
-    SideBracketPadVisAtt->SetVisibility(true);
+    SideBracketPadVisAtt->SetVisibility(false);
 //SideBracketPadVisAtt->SetForceWireframe(true);
     SideBracketPadVisAtt->SetForceSolid(true);
     SideBracketPad_Logical->SetVisAttributes(SideBracketPadVisAtt);
@@ -2237,7 +2237,7 @@ void QweakSimCerenkovDetector::ConstructComponent(G4VPhysicalVolume* MotherVolum
 // Visual Attributes for:  End Bracket Pads
 //------------------------------------------
     G4VisAttributes* EndBracketPadVisAtt = new G4VisAttributes(brown);
-    EndBracketPadVisAtt->SetVisibility(true);
+    EndBracketPadVisAtt->SetVisibility(false);
 //EndBracketPadVisAtt->SetForceWireframe(true);
 EndBracketPadVisAtt->SetForceSolid(true);
     EndBracketPad_Logical->SetVisAttributes(EndBracketPadVisAtt);
@@ -2247,7 +2247,7 @@ EndBracketPadVisAtt->SetForceSolid(true);
 // Visual Attributes for:  Detector Window Clip
 //------------------------------------------
     G4VisAttributes* ClipVisAtt = new G4VisAttributes(lightorange);
-    ClipVisAtt->SetVisibility(true);
+    ClipVisAtt->SetVisibility(false);
 //ClipVisAtt->SetForceWireframe(true);
 //ClipVisAtt->SetForceSolid(true);
     FrontClip_Logical->SetVisAttributes(ClipVisAtt);
@@ -2259,7 +2259,7 @@ EndBracketPadVisAtt->SetForceSolid(true);
     G4VisAttributes* CerenkovDetectorVisAtt = new G4VisAttributes(orange);
     CerenkovDetectorVisAtt->SetVisibility(true);
 // Needed for the correct visualization using Coin3D
-//CerenkovDetectorVisAtt->SetForceSolid(true);
+    //CerenkovDetectorVisAtt->SetForceSolid(true);
     CerenkovDetectorVisAtt->SetForceWireframe(true);
 //  ActiveArea_Logical->SetVisAttributes(CerenkovDetectorVisAtt);
     QuartzBar_LogicalLeft->SetVisAttributes(CerenkovDetectorVisAtt);
@@ -2272,7 +2272,7 @@ EndBracketPadVisAtt->SetForceSolid(true);
 // Visual Attributes for:  PMTContainer
 //------------------------------------------------
     G4VisAttributes* PMTContainerVisAtt = new G4VisAttributes(blue);
-    PMTContainerVisAtt->SetVisibility(true);
+    PMTContainerVisAtt->SetVisibility(false);
     PMTContainerVisAtt->SetForceWireframe(true);
 //PMTContainerVisAtt->SetForceSolid(true);
     PMTContainer_Logical->SetVisAttributes(PMTContainerVisAtt);
@@ -2281,7 +2281,7 @@ EndBracketPadVisAtt->SetForceSolid(true);
 // Visual Attributes for:  PMTEntranceWindow
 //-----------------------------------------------------
     G4VisAttributes* PMTEntranceWindowVisAtt = new G4VisAttributes(grey);
-    PMTEntranceWindowVisAtt->SetVisibility(true);
+    PMTEntranceWindowVisAtt->SetVisibility(false);
 //PMTEntranceWindowVisAtt->SetForceWireframe(true);
     PMTEntranceWindowVisAtt->SetForceSolid(true);
     PMTEntranceWindow_Logical->SetVisAttributes(PMTEntranceWindowVisAtt);

--- a/src/QweakSimDetectorConstruction.cc
+++ b/src/QweakSimDetectorConstruction.cc
@@ -103,7 +103,7 @@ QweakSimDetectorConstruction::QweakSimDetectorConstruction(QweakSimUserInformati
 
   pMagneticField = NULL;
 
-  pTriggerScintillator  = NULL;
+  //pTriggerScintillator  = NULL;
   pCerenkovDetector     = NULL;
   pLumiDetector     = NULL;
 
@@ -126,12 +126,12 @@ QweakSimDetectorConstruction::QweakSimDetectorConstruction(QweakSimUserInformati
   pPMTOnly		 = NULL;
 
   // pGEM               = NULL;
-  pHDC               = NULL;
-  pVDC               = NULL;
-  pVDCRotator        = NULL;
+  //pHDC               = NULL;
+  //pVDC               = NULL;
+  //pVDCRotator        = NULL;
 
   pTarget            = NULL;
-  pBeamLine          = NULL;
+  // pBeamLine          = NULL;
   pMainMagnet        = NULL;
 
   fWorldLengthInX = 0.0*cm;
@@ -164,14 +164,14 @@ QweakSimDetectorConstruction::~QweakSimDetectorConstruction()
 
   if (pMagneticField) delete pMagneticField;
 
-  if (pVDCRotator) delete pVDCRotator;
+  //if (pVDCRotator) delete pVDCRotator;
   // if (pGEM)        delete pGEM;
-  if (pHDC)        delete pHDC;
-  if (pVDC)        delete pVDC;
+  //if (pHDC)        delete pHDC;
+  //if (pVDC)        delete pVDC;
 
   if (pLumiDetector)    delete pLumiDetector;
   if (pCerenkovDetector)    delete pCerenkovDetector;
-  if (pTriggerScintillator) delete pTriggerScintillator;
+  // if (pTriggerScintillator) delete pTriggerScintillator;
 
   if (pTungstenPlug)        delete pTungstenPlug;
   if (pCollimator1)         delete pCollimator1;
@@ -192,7 +192,7 @@ QweakSimDetectorConstruction::~QweakSimDetectorConstruction()
   if (pPMTOnly)		    delete pPMTOnly;
 
   if (pTarget)              delete pTarget;
-  if (pBeamLine)            delete pBeamLine;
+  // if (pBeamLine)            delete pBeamLine;
   if (pMainMagnet)          delete pMainMagnet;
 
   if (detectorMessenger)    delete detectorMessenger;
@@ -210,7 +210,7 @@ G4VPhysicalVolume* QweakSimDetectorConstruction::Construct()
 G4VPhysicalVolume* QweakSimDetectorConstruction::ConstructQweak()
 {
   pTarget              = new QweakSimTarget(myUserInfo);
-  pBeamLine            = new QweakSimBeamLine(myUserInfo);
+  //pBeamLine            = new QweakSimBeamLine(myUserInfo);
   
   pTungstenPlug        = new QweakSimTungstenPlug();
   pCollimator1         = new QweakSimCollimator();
@@ -232,14 +232,14 @@ G4VPhysicalVolume* QweakSimDetectorConstruction::ConstructQweak()
   pMainMagnet          = new QweakSimMainMagnet(); // QTOR Geometry (decoupled from field)
 
   //pGEM                 = new QweakSimGEM();
-  pHDC                 = new QweakSimHDC();
-  pVDC                 = new QweakSimVDC();
-  pVDCRotator          = new QweakSimVDCRotator();
+  //pHDC                 = new QweakSimHDC();
+  //pVDC                 = new QweakSimVDC();
+  //pVDCRotator          = new QweakSimVDCRotator();
 
   pCerenkovDetector    = new QweakSimCerenkovDetector(myUserInfo);
   pLumiDetector        = new QweakSimLumiDetector();
 
-  pTriggerScintillator = new QweakSimTriggerScintillator();
+  //pTriggerScintillator = new QweakSimTriggerScintillator();
 
 
   //--------- Definitions of Solids, Logical Volumes, Physical Volumes ---------
@@ -348,15 +348,15 @@ G4VPhysicalVolume* QweakSimDetectorConstruction::ConstructQweak()
     pGeometry->AddModule(pTarget->getTargetPhysicalVolume());
   }
 
-  //============================================
-  // create/place beamline body into MotherVolume
-  //============================================
-  //
-  if (pBeamLine) {
-    pBeamLine -> ConstructComponent(experimentalHall_Physical);
-    //pBeamLine -> SetBeamLineCenterPositionInZ(300.0*cm);
-    //pGeometry->AddModule(pBeamLine->getBeamLinePhysicalVolume());
-  }
+  // //============================================
+  // // create/place beamline body into MotherVolume
+  // //============================================
+  // //
+  // if (pBeamLine) {
+  //   pBeamLine -> ConstructComponent(experimentalHall_Physical);
+  //   //pBeamLine -> SetBeamLineCenterPositionInZ(300.0*cm);
+  //   //pGeometry->AddModule(pBeamLine->getBeamLinePhysicalVolume());
+  // }
   
   //================================================
   // create/place MainMagnet body into MotherVolume
@@ -612,46 +612,46 @@ G4VPhysicalVolume* QweakSimDetectorConstruction::ConstructQweak()
   //  pGeometry->AddModule(pGEM->getGEMBack_PhysicalVolume());
   //}
   //
-  if (pHDC) {
-    pHDC->ConstructComponent(experimentalHall_Physical);
-    pGeometry->AddModule(pHDC->getHDCFront_PhysicalVolume());
-    pGeometry->AddModule(pHDC->getHDCBack_PhysicalVolume());
-  }
+  // if (pHDC) {
+  //   pHDC->ConstructComponent(experimentalHall_Physical);
+  //   pGeometry->AddModule(pHDC->getHDCFront_PhysicalVolume());
+  //   pGeometry->AddModule(pHDC->getHDCBack_PhysicalVolume());
+  // }
   //===============================================
   // create/place VDC Rotator into MotherVolume
   //===============================================
   //
-  if (pVDCRotator) {
-    pVDCRotator->SetMotherVolume(experimentalHall_Physical);
-    pVDCRotator->ConstructRotatorMasterContainer();
-    pVDCRotator->ConstructRings();
-    pVDCRotator->ConstructRails();
-    pVDCRotator->ConstructMount();
-    pVDCRotator->ConstructSliderSupport();
-    pVDCRotator->SetRotationAngleInPhi( 90.0*degree);
-  }
+  // if (pVDCRotator) {
+  //   pVDCRotator->SetMotherVolume(experimentalHall_Physical);
+  //   pVDCRotator->ConstructRotatorMasterContainer();
+  //   pVDCRotator->ConstructRings();
+  //   pVDCRotator->ConstructRails();
+  //   pVDCRotator->ConstructMount();
+  //   pVDCRotator->ConstructSliderSupport();
+  //   pVDCRotator->SetRotationAngleInPhi( 90.0*degree);
+  // }
 
 
   //=====================================================
   // create/place Trigger Scintillator into MotherVolume
   //=====================================================
   //
-  if (pTriggerScintillator) {
-    pTriggerScintillator->ConstructComponent(experimentalHall_Physical);
-    //
-    pGeometry->AddModule(pTriggerScintillator->GetTriggerScintillator_PhysicalVolume());
-  }
+  // if (pTriggerScintillator) {
+  //   pTriggerScintillator->ConstructComponent(experimentalHall_Physical);
+  //   //
+  //   pGeometry->AddModule(pTriggerScintillator->GetTriggerScintillator_PhysicalVolume());
+  // }
 
   //
-  if (pVDC) {
-    pVDC->ConstructComponent(experimentalHall_Physical);
-    pGeometry->AddModule(pVDC->getVDCFront_PhysicalVolume());
-    pGeometry->AddModule(pVDC->getVDCBack_PhysicalVolume());
-    pVDC->SetVDCRotator(pVDCRotator);
-    pVDC->SetTriggerScintillator(pTriggerScintillator);
-    pVDC->SetVDC_RotationAngleInPhi(90.0*degree,0);
-    pVDC->SetVDC_RotationAngleInPhi(270.0*degree,1);
-  }
+  // if (pVDC) {
+  //   pVDC->ConstructComponent(experimentalHall_Physical);
+  //   pGeometry->AddModule(pVDC->getVDCFront_PhysicalVolume());
+  //   pGeometry->AddModule(pVDC->getVDCBack_PhysicalVolume());
+  //   pVDC->SetVDCRotator(pVDCRotator);
+  //   pVDC->SetTriggerScintillator(pTriggerScintillator);
+  //   pVDC->SetVDC_RotationAngleInPhi(90.0*degree,0);
+  //   pVDC->SetVDC_RotationAngleInPhi(270.0*degree,1);
+  // }
 
 
   //=========================================

--- a/src/QweakSimPrimaryGeneratorAction.cc
+++ b/src/QweakSimPrimaryGeneratorAction.cc
@@ -97,6 +97,20 @@ void QweakSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     G4double myNormMomentumX, myNormMomentumY, myNormMomentumZ;
     G4double E_beam;  // Energy of the incoming and outgoing particle
 
+
+    myPositionX =  myUserInfo->GetBeamPositionX();
+    myPositionY =  myUserInfo->GetBeamPositionY();
+    myPositionZ =  myUserInfo->GetBeamPositionZ();
+
+    myNormMomentumX  = tan(myUserInfo->GetNormMomentumX()); // = 0
+    myNormMomentumY  = tan(myUserInfo->GetNormMomentumY()); // = 0
+    myNormMomentumZ  = sqrt(1.0 - myNormMomentumX * myNormMomentumX - myNormMomentumY * myNormMomentumY);  // = 1
+
+    E_beam = myUserInfo->GetBeamEnergy() - 0.511*MeV;
+
+    myUserInfo->StoreOriginVertexPositionZ(myEvent->GetVertexZ());
+    myUserInfo->EvtGenStatus = 0; // checked in QweakSimSteppingAction.cc
+
 //   if (myEventCounter%3 == 0) { // for even myEventCounter
 //     // select position in x & y randomly
 //     myPositionX =  myUserInfo->GetBeamPositionX() + (G4UniformRand()-0.5)*(fPositionX_max-fPositionX_min)+(fPositionX_max+fPositionX_min)/2.0;
@@ -137,27 +151,28 @@ void QweakSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 //     }
 //   }
 //
-    //   Relocate the beam gun to the Cerenkov bar to test the light distributions
-    E_beam = myUserInfo->GetBeamEnergy() - 0.511*MeV;
-    myUserInfo->StoreOriginVertexPositionZ(myEvent->GetVertexZ());
-    myUserInfo->EvtGenStatus = 0; // checked in QweakSimSteppingAction.cc
+    // //   Relocate the beam gun to the Cerenkov bar to test the light distributions
+    // E_beam = myUserInfo->GetBeamEnergy() - 0.511*MeV;
+    // myUserInfo->StoreOriginVertexPositionZ(myEvent->GetVertexZ());
+    // myUserInfo->EvtGenStatus = 0; // checked in QweakSimSteppingAction.cc
 
-    G4double PositionX_min = -100.0*cm;
-    G4double PositionX_max =  100.0*cm;
-    myPositionX =  (G4UniformRand()-0.5)*(PositionX_max-PositionX_min)+(PositionX_max+PositionX_min)/2.0;
+    // // G4double PositionX_min = -100.0*cm;
+    // // G4double PositionX_max =  100.0*cm;
+    // // myPositionX =  (G4UniformRand()-0.5)*(PositionX_max-PositionX_min)+(PositionX_max+PositionX_min)/2.0;
 
-    G4double PositionY_min = (328.-9.0)*cm;
-    G4double PositionY_max = (328.+9.0)*cm;
-    myPositionY =  (G4UniformRand()-0.5)*(PositionY_max-PositionY_min)+(PositionY_max+PositionY_min)/2.0;
+    // // G4double PositionY_min = (328.-9.0)*cm;
+    // // G4double PositionY_max = (328.+9.0)*cm;
+    // // myPositionY =  (G4UniformRand()-0.5)*(PositionY_max-PositionY_min)+(PositionY_max+PositionY_min)/2.0;
 
-    myPositionX =   0.0*cm;
-    myPositionY = 335.0*cm;
-    myPositionZ = 560.0*cm;
-    //G4cout<<" Particle with x,y,z "<<myPositionX/cm<<" "<<myPositionY/cm<<" "<<myPositionZ/cm<<G4endl;
-    myNormMomentumX  = 0.0;
-    myNormMomentumY  = 0.0;
-    myNormMomentumZ  = 1.0;
-    //
+    // // myPositionX =   0.0*cm;
+    // // myPositionY = 335.0*cm;
+    // // myPositionZ = 560.0*cm;
+    // // //G4cout<<" Particle with x,y,z "<<myPositionX/cm<<" "<<myPositionY/cm<<" "<<myPositionZ/cm<<G4endl;
+    // // myNormMomentumX  = 0.0;
+    // // myNormMomentumY  = 0.0;
+    // // myNormMomentumZ  = 1.0;
+    // // //
+
 
     particleGun->SetParticlePosition(G4ThreeVector(myPositionX,
                                      myPositionY,
@@ -173,9 +188,9 @@ void QweakSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
     particleGun->SetParticleEnergy(E_beam);
 
-  particleGun->SetParticleMomentumDirection(G4ThreeVector(myNormMomentumX,
-                                                          myNormMomentumY,
-                                                          myNormMomentumZ));
+    particleGun->SetParticleMomentumDirection(G4ThreeVector(myNormMomentumX,
+							    myNormMomentumY,
+							    myNormMomentumZ));
 
   if (fPolarization == "L") {
     // longitudinal polarization (after generation)

--- a/src/QweakSimPrimaryGeneratorAction.cc
+++ b/src/QweakSimPrimaryGeneratorAction.cc
@@ -43,27 +43,27 @@ QweakSimPrimaryGeneratorAction::QweakSimPrimaryGeneratorAction( QweakSimUserInfo
     fPositionX_max =  2.0*mm;
     fPositionY_min = -2.0*mm;
     fPositionY_max =  2.0*mm;
-
-  fPolarization = "L";
-
-  myUserInfo = myUI;
-  myEvent = myEPEvent;
-   
-  // get my messenger
-  myMessenger = new QweakSimPrimaryGeneratorActionMessenger(this);
-
+    
+    fPolarization = "L";
+    
+    myUserInfo = myUI;
+    myEvent = myEPEvent;
+    
     // get my messenger
     myMessenger = new QweakSimPrimaryGeneratorActionMessenger(this);
-
+    
+    // get my messenger
+    myMessenger = new QweakSimPrimaryGeneratorActionMessenger(this);
+    
     // initialize my own event counter
     // myEventCounter = 0;
-
+    
     G4int n_particle = 1;
     particleGun = new G4ParticleGun(n_particle);
     SetParticleType("e-");
-
+    
     myEvent->SetBeamEnergy();
-
+    
     G4cout << "###### Leaving QweakSimPrimaryGeneratorAction::QweakSimPrimaryGeneratorAction " << G4endl;
 }
 
@@ -175,54 +175,53 @@ void QweakSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 
     particleGun->SetParticlePosition(G4ThreeVector(myPositionX,
-                                     myPositionY,
-                                     myPositionZ ));
+						   myPositionY,
+						   myPositionZ ));
+    
+    //Buddhini - Hard code the gun to spit out particles in +-20 deg angles in the horizontal plane.
 
-    particleGun->SetParticleMomentumDirection(G4ThreeVector(myNormMomentumX,
-            myNormMomentumY,
-            myNormMomentumZ));
+    G4double theta_x = 0.0;
+    theta_x = CLHEP::RandFlat::shoot(-20,20);
+    G4cout<<"$$$$ theta_x "<<theta_x<<G4endl;
+    G4ThreeVector momDir;
+    momDir.setRThetaPhi(1.,theta_x*deg,0*deg);
+    particleGun->SetParticleMomentumDirection(momDir);
 
-    particleGun->SetParticlePolarization(-(G4ThreeVector(myNormMomentumX,
-                                           myNormMomentumY,
-                                           myNormMomentumZ)));
-
+    // particleGun->SetParticleMomentumDirection(G4ThreeVector(myNormMomentumX,
+    // 							    myNormMomentumY,
+    // 							    myNormMomentumZ));
+    
+    if (fPolarization == "L") {
+      // longitudinal polarization (after generation)
+      particleGun->SetParticlePolarization((G4ThreeVector(myNormMomentumX,
+							  myNormMomentumY,
+							  myNormMomentumZ)));
+    }
+    if (fPolarization == "V") {
+      // vertical transverse polarization (after generation)
+      particleGun->SetParticlePolarization(G4ThreeVector(myNormMomentumX,
+							 myNormMomentumY,
+							 myNormMomentumZ)
+					   .cross(G4ThreeVector(1,0,0)));
+    }
+    if (fPolarization == "H") {
+      // horizontal transverse polarization (after generation)
+      particleGun->SetParticlePolarization(G4ThreeVector(myNormMomentumX,
+							 myNormMomentumY,
+							 myNormMomentumZ)
+					   .cross(G4ThreeVector(0,1,0)));
+    }
+    
     particleGun->SetParticleEnergy(E_beam);
-
-    particleGun->SetParticleMomentumDirection(G4ThreeVector(myNormMomentumX,
-							    myNormMomentumY,
-							    myNormMomentumZ));
-
-  if (fPolarization == "L") {
-    // longitudinal polarization (after generation)
-    particleGun->SetParticlePolarization((G4ThreeVector(myNormMomentumX,
-                                                        myNormMomentumY,
-                                                        myNormMomentumZ)));
-  }
-  if (fPolarization == "V") {
-    // vertical transverse polarization (after generation)
-    particleGun->SetParticlePolarization(G4ThreeVector(myNormMomentumX,
-                                                       myNormMomentumY,
-                                                       myNormMomentumZ)
-                                  .cross(G4ThreeVector(1,0,0)));
-  }
-  if (fPolarization == "H") {
-    // horizontal transverse polarization (after generation)
-    particleGun->SetParticlePolarization(G4ThreeVector(myNormMomentumX,
-                                                       myNormMomentumY,
-                                                       myNormMomentumZ)
-                                  .cross(G4ThreeVector(0,1,0)));
-  }
-
-  particleGun->SetParticleEnergy(E_beam);
-
-  // finally : fire !!!
-  particleGun->GeneratePrimaryVertex(anEvent);  // takes an event, generates primary vertex, and associates primary particles with the vertex
-  myUserInfo->StorePrimaryEventNumber(myEventCounter+1);
-  //myUserInfo->SetBeamEnergy(myEvent->GetBeamEnergy());
+    
+    // finally : fire !!!
+    particleGun->GeneratePrimaryVertex(anEvent);  // takes an event, generates primary vertex, and associates primary particles with the vertex
+    myUserInfo->StorePrimaryEventNumber(myEventCounter+1);
+    //myUserInfo->SetBeamEnergy(myEvent->GetBeamEnergy());
     // rest of userInfo filled in QweakSimSteppingAction.cc
-
-//  G4cout << "###### Leaving QweakSimPrimaryGeneratorAction::GeneratePrimaries" << G4endl;
-
+    
+    //  G4cout << "###### Leaving QweakSimPrimaryGeneratorAction::GeneratePrimaries" << G4endl;
+    
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/QweakSimPrimaryGeneratorActionMessenger.cc
+++ b/src/QweakSimPrimaryGeneratorActionMessenger.cc
@@ -82,6 +82,13 @@ QweakSimPrimaryGeneratorActionMessenger::QweakSimPrimaryGeneratorActionMessenger
   SetPositionY_Cmd->SetDefaultValue(0.0*mm);
   SetPositionY_Cmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
+  SetPositionZ_Cmd = new G4UIcmdWithADoubleAndUnit("/PrimaryEvent/SetBeamPositionZ",this);
+  SetPositionZ_Cmd->SetGuidance("Set beam position in z");
+  SetPositionZ_Cmd->SetParameterName("z",true);
+  SetPositionZ_Cmd->SetUnitCategory("Length");
+  SetPositionZ_Cmd->SetDefaultValue(0.0*mm);
+  SetPositionZ_Cmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
   SetDirectionX_Cmd = new G4UIcmdWithADoubleAndUnit("/PrimaryEvent/SetBeamDirectionX",this);
   SetDirectionX_Cmd->SetGuidance("Set beam direction in x");
   SetDirectionX_Cmd->SetParameterName("x",true);
@@ -175,6 +182,12 @@ void QweakSimPrimaryGeneratorActionMessenger::SetNewValue(G4UIcommand* command, 
       G4cout << "#### Messenger: Setting Beam Position in Y to " << newValue << G4endl;
       G4double y = SetPositionY_Cmd->GetNewDoubleValue(newValue);
       pPrimaryGeneratorAction->GetUserInfo()->SetBeamPositionY(y);
+    }
+  if( command == SetPositionZ_Cmd )
+    {
+      G4cout << "#### Messenger: Setting Beam Position in Z to " << newValue << G4endl;
+      G4double z = SetPositionZ_Cmd->GetNewDoubleValue(newValue);
+      pPrimaryGeneratorAction->GetUserInfo()->SetBeamPositionZ(z);
     }
   if( command == SetDirectionX_Cmd )
     {

--- a/src/QweakSimUserInformation.cc
+++ b/src/QweakSimUserInformation.cc
@@ -18,7 +18,7 @@ void QweakSimUserInformation::Print() const
   G4cout << "**** Calling QweakSimUserInformation::Print() ****" << G4endl;
   G4cout << "Primary Event #:: " << PrimaryEventNumber << G4endl;
   G4cout << "Reaction type:: " << ReactionType << G4endl;
-  G4cout << "Beam pos:: " << fPositionX << "\t" << fPositionY << G4endl;
+  G4cout << "Beam pos:: " << fPositionX << "\t" << fPositionY << "\t"<<fPositionZ << G4endl;
   G4cout << "Tgt center z:: " << TargetCenterPositionZ << G4endl;
   G4cout << "Tgt length:: " << TargetLength << G4endl;
   G4cout << "Beam mom:: " << fNormMomentumX << "\t" << fNormMomentumY << G4endl;
@@ -47,6 +47,8 @@ void QweakSimUserInformation::Initialize()
 
   fPositionX = 0.0*mm;
   fPositionY = 0.0*mm;
+  fPositionZ = 0.0*mm;
+
   fNormMomentumX = 0.0*mrad;
   fNormMomentumY = 0.0*mrad;
   


### PR DESCRIPTION
With this commit we can set the beam position in X, Y, Z in side the macros using:
/PrimaryEvent/SetBeamPositionX xx cm
/PrimaryEvent/SetBeamPositionY xx cm
/PrimaryEvent/SetBeamPositionZ xx cm
If the beam position is not set via above commands, the beam starts at (0,0,0).

No need to change the .cc files to move the beam position. 
myQweakCerenkovOnly.mac is the macro I'm using to change the configuration for my tests. But it uses the above commands.
